### PR TITLE
Add PMTK GPS helper script, minor fixes and improvements to ptp4l-gm-set.sh

### DIFF
--- a/files/ptp4l-gm-set.sh
+++ b/files/ptp4l-gm-set.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 . /etc/default/ptp4l-gm
+
+# Wait for ptp4l UDS socket to appear
+for i in {1..10}; do
+  if [ -S /var/run/ptp4l ]; then
+    break
+  fi
+  echo "Waiting for ptp4l to be ready..."
+  sleep 0.5
+done
+
 /usr/sbin/pmc -u -b 0 \
 "set GRANDMASTER_SETTINGS_NP
 		clockClass              6
@@ -8,7 +18,7 @@
                 currentUtcOffset        $UTC_OFFSET
                 leap61                  0
                 leap59                  0
-                currentUtcOffsetValid   1 
+                currentUtcOffsetValid   1
                 ptpTimescale            1
                 timeTraceable           1
                 frequencyTraceable      0

--- a/files/send_pmtk.py
+++ b/files/send_pmtk.py
@@ -1,0 +1,58 @@
+import argparse
+import serial
+import time
+
+def calculate_checksum(sentence):
+    checksum = 0
+    for char in sentence:
+        checksum ^= ord(char)
+    return f"{checksum:02X}"
+
+def build_pmtk_command(command_num, data=None):
+    base = f"PMTK{command_num}"
+    if data:
+        base += f",{data}"
+    checksum = calculate_checksum(base)
+    return f"${base}*{checksum}\r\n"
+
+def send_pmtk(port, baudrate, command_num, data):
+    cmd = build_pmtk_command(command_num, data)
+    print(f"Sending to {port} at {baudrate} baud:\n{cmd.strip()}")
+    with serial.Serial(port, baudrate, timeout=1) as ser:
+        ser.write(cmd.encode('ascii'))
+        return True
+    return False
+
+def listen_for_responses(port, baudrate, timeout=None, show_all=False):
+    print(f"Listening on {port} at {baudrate} baud... Press Ctrl+C to stop.")
+    start_time = time.time()
+    try:
+        with serial.Serial(port, baudrate, timeout=0.5) as ser:
+            while True:
+                line = ser.readline().decode('ascii', errors='ignore').strip()
+                if line:
+                    if show_all or "PMTK" in line:
+                        print(line)
+                if timeout and (time.time() - start_time > timeout):
+                    break
+    except KeyboardInterrupt:
+        print("\nStopped by user.")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Send PMTK command and/or listen to GPS output")
+    parser.add_argument("command", nargs="?", help="PMTK command number (e.g., 000, 220)")
+    parser.add_argument("data", nargs="?", default=None, help="Optional PMTK command data")
+    parser.add_argument("--port", default="/dev/ttyAMA0", help="Serial port (default: /dev/ttyAMA0)")
+    parser.add_argument("--baud", type=int, default=9600, help="Baud rate (default: 9600)")
+    parser.add_argument("--listen", action="store_true", help="Just listen to all GPS output (like cat)")
+    parser.add_argument("--timeout", type=int, default=5, help="Response timeout in seconds (default: 5)")
+
+    args = parser.parse_args()
+
+    if args.listen and not args.command:
+        listen_for_responses(args.port, args.baud, show_all=True)
+    elif args.command:
+        if send_pmtk(args.port, args.baud, args.command, args.data):
+            listen_for_responses(args.port, args.baud, timeout=args.timeout, show_all=False)
+    else:
+        parser.print_help()


### PR DESCRIPTION
This PR includes the following changes:

New Feature:
- Added a helper script for sending and receiving PMTK commands to/from GPS modules. This is useful for debugging or configuring GPS units that support the PMTK command set.
- python files/send_pmtk.py (to run it, uses argparse for neater cli help)

Improvement to ptp4l-gm-set.sh:
- Added a delay to ensure ptp4l is fully up before sending pmc commands. Without this, PMC may fail to apply settings reliably.
- Removed an unnecessary extra space.

I mainly created this for my own benefit, but it might be useful for someone else. 😄 